### PR TITLE
Function pointer dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++14 -g -Wall -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++14 -g -Wall -Wextra")
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
-add_executable(tests unit_tests.cpp)
+add_executable(tests any.hpp unit_tests.cpp)
 target_link_libraries(tests ${GTEST_BOTH_LIBRARIES} pthread)
 
 

--- a/any.hpp
+++ b/any.hpp
@@ -6,6 +6,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <cassert>
+#include <iostream>
 
 namespace detail
 {
@@ -92,17 +93,17 @@ struct any_p
     any_p() = default;
 
     /// Creates any_p containing a copy v
-    template<typename _T>
-    any_p(const _T& v)
-    {
-        copy_object(v);
-    }
+//    template<typename _T>
+//    any_p(const _T& v)
+//    {
+//        copy_object(v);
+//    }
 
     /// Creates any_p containing moved v
     template<typename _T>
-    any_p(const _T&& v)
+    any_p(_T&& v)
     {
-        move_object(v);
+        copy_or_move(std::forward<_T>(v));
     }
 
     ~any_p()
@@ -110,53 +111,39 @@ struct any_p
         destroy();
     }
 
-    template <typename _T>
-    any_p& operator=(const _T& t)
-    {
-        destroy();
-        copy_object(t);
-        return *this;
-    }
+//    template <typename _T>
+//    any_p& operator=(const _T& t)
+//    {
+//        destroy();
+//        copy_object(t);
+//        return *this;
+//    }
 
     template <typename _T>
     any_p& operator=(_T&& t)
     {
         destroy();
-        move_object(t);
+        copy_or_move(std::forward<_T>(t));
         return *this;
     }
 
-//    template <typename _T>
-//    typename std::enable_if<!std::is_pointer<_T>::value, _T&>::type
-//    get()
-//    {
-//        is_stored_type<_T>();
-//        return reinterpret_cast<_T&>(*buff_.data());
-//    }
+    template<typename _T>
+    const _T& get() const
+    {
+        if (!is_stored_type<_T>())
+            throw std::bad_cast();
 
-//    template <typename _T>
-//    typename std::enable_if<!std::is_pointer<_T>::value, const _T&>::type
-//    get() const
-//    {
-//        is_stored_type<_T>();
-//        return reinterpret_cast<const _T&>(*buff_.data());
-//    }
+        return *as<_T>();
+    }
 
-//    template <typename _T>
-//    typename std::enable_if<std::is_pointer<_T>::value, _T>::type
-//    get()
-//    {
-//        is_stored_type<_T>();
-//        return reinterpret_cast<_T>(buff_.data());
-//    }
+    template<typename _T>
+    _T& get()
+    {
+        if (!is_stored_type<_T>())
+            throw std::bad_cast();
 
-//    template <typename _T>
-//    typename std::enable_if<std::is_pointer<_T>::value, const _T>::type
-//    get() const
-//    {
-//        is_stored_type<_T>();
-//        return reinterpret_cast<const _T>(buff_.data());
-//    }
+        return *as<_T>();
+    }
 
     template <typename _T>
     bool is_stored_type() const
@@ -172,56 +159,71 @@ private:
     using function_ptr_t = void(*)(operation_t operation, void* this_ptr, void* other_ptr);
 
     template<typename _T>
+    static void operation(operation_t operation, void* this_void_ptr, void* other_void_ptr)
+    {
+        _T* this_ptr = reinterpret_cast<_T*>(this_void_ptr);
+        _T* other_ptr = reinterpret_cast<_T*>(other_void_ptr);
+
+        switch(operation)
+        {
+            case operation_t::copy:
+                assert(this_ptr);
+                assert(other_ptr);
+                new(this_ptr)_T(*other_ptr);
+                break;
+            case operation_t::move:
+                assert(this_ptr);
+                assert(other_ptr);
+                new(this_ptr)_T(std::move(*other_ptr));
+                break;
+            case operation_t::destroy:
+                assert(this_ptr);
+                this_ptr->~_T();
+                break;
+        }
+    }
+
+    template<typename _T>
     static function_ptr_t get_function_for_type()
     {
-        return [](operation_t operation, void* this_void_ptr, void* other_void_ptr)
-        {
-            _T* this_ptr = reinterpret_cast<_T*>(this_void_ptr);
-            _T* other_ptr = reinterpret_cast<_T*>(other_void_ptr);
-
-            switch(operation)
-            {
-                case operation_t::copy:
-                    assert(this_ptr);
-                    assert(other_ptr);
-                    new(this_ptr)_T(*other_ptr);
-                    break;
-                case operation_t::move:
-                    assert(this_ptr);
-                    assert(other_ptr);
-                    new(this_ptr)_T(std::move(*other_ptr));
-                    break;
-                case operation_t::destroy:
-                    assert(this_ptr);
-                    this_ptr->~_T();
-                    break;
-            }
-        };
+        return &any_p::operation<_T>;
     }
 
+//    template <typename _T>
+//    void copy_object(const _T& t)
+//    {
+//        static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
+//        assert(!function_);
+//        using NonConstT = std::remove_cv_t<_T>;
+//        function_ = get_function_for_type<NonConstT>();
+//        _T* non_const_t = const_cast<_T*>(&t);
+//        function_(operation_t::copy, buff_.data(), non_const_t);
+//    }
+
     template <typename _T>
-    void copy_object(const _T& t)
+    void copy_or_move(_T&& t)
     {
         static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
         assert(!function_);
-        using NonConstT = std::remove_cv_t<_T>;
+        using NonConstT = std::remove_cv_t<std::remove_reference_t<_T>>;
         function_ = get_function_for_type<NonConstT>();
-        _T* non_const_t = const_cast<_T*>(&t);
-        function_(operation_t::copy, buff_.data(), non_const_t);
-    }
-
-    template <typename _T>
-    void move_object(_T& t)
-    {
-        static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
-        assert(!function_);
-        using NonConstT = std::remove_cv_t<_T>;
-        function_ = get_function_for_type<NonConstT>();
-        //TP<_T> x;
         NonConstT* non_const_t = const_cast<NonConstT*>(&t);
-        function_(operation_t::move, buff_.data(), &non_const_t);
+        call_function<_T&&>(buff_.data(), non_const_t);
     }
 
+    template <typename Ref>
+    std::enable_if_t<std::is_rvalue_reference<Ref>::value>
+    call_function(void* this_void_ptr, void* other_void_ptr)
+    {
+        function_(operation_t::move, this_void_ptr, other_void_ptr);
+    }
+
+    template <typename Ref>
+    std::enable_if_t<!std::is_rvalue_reference<Ref>::value>
+    call_function(void* this_void_ptr, void* other_void_ptr)
+    {
+        function_(operation_t::copy, this_void_ptr, other_void_ptr);
+    }
 
     void destroy()
     {
@@ -230,6 +232,18 @@ private:
             function_(operation_t::destroy, buff_.data(), nullptr);
             function_ = nullptr;
         }
+    }
+
+    template<typename _T>
+    const _T* as() const
+    {
+        return reinterpret_cast<const _T*>(buff_.data());
+    }
+
+    template<typename _T>
+    _T* as()
+    {
+        return reinterpret_cast<_T*>(buff_.data());
     }
 
     std::array<char, _N> buff_;

--- a/any.hpp
+++ b/any.hpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <type_traits>
 #include <typeinfo>
+#include <cassert>
 
 namespace detail
 {
@@ -76,82 +77,161 @@ private:
     std::array<char, _N> buff_;
 };
 
-template <std::size_t _N, typename _DeleterT = void>
-struct any_p : public detail::deleter<_DeleterT, any_p<_N>>
+template<typename T> class TP;
+
+template <std::size_t _N>
+struct any_p
 {
     typedef std::size_t size_type;
 
     static constexpr size_type size() { return _N; }
 
-    template <typename _T,
-              typename _D = _DeleterT>
-    typename std::enable_if<std::is_same<_D, void>::value, any_p&>::type
-    operator=(_T&& t)
+    bool empty() const { return function_ == nullptr; }
+
+    /// Creates empty object
+    any_p() = default;
+
+    /// Creates any_p containing a copy v
+    template<typename _T>
+    any_p(const _T& v)
     {
-        static_assert(std::is_trivially_destructible<_T>::value, "_T is not trivially destructible and does not use any_p deleter");
-        copy_object(std::move(t));
+        copy_object(v);
+    }
+
+    /// Creates any_p containing moved v
+    template<typename _T>
+    any_p(const _T&& v)
+    {
+        move_object(v);
+    }
+
+    ~any_p()
+    {
+        destroy();
+    }
+
+    template <typename _T>
+    any_p& operator=(const _T& t)
+    {
+        destroy();
+        copy_object(t);
         return *this;
     }
 
-    template <typename _T,
-              typename _D = _DeleterT>
-    typename std::enable_if<!std::is_same<_D, void>::value, any_p&>::type
-    operator=(_T&& t)
+    template <typename _T>
+    any_p& operator=(_T&& t)
     {
-        copy_object(std::move(t));
+        destroy();
+        move_object(t);
         return *this;
     }
 
-    template <typename _T>
-    typename std::enable_if<!std::is_pointer<_T>::value, _T&>::type
-    get()
-    {
-        is_stored_type<_T>();
-        return reinterpret_cast<_T&>(*buff_.data());
-    }
+//    template <typename _T>
+//    typename std::enable_if<!std::is_pointer<_T>::value, _T&>::type
+//    get()
+//    {
+//        is_stored_type<_T>();
+//        return reinterpret_cast<_T&>(*buff_.data());
+//    }
+
+//    template <typename _T>
+//    typename std::enable_if<!std::is_pointer<_T>::value, const _T&>::type
+//    get() const
+//    {
+//        is_stored_type<_T>();
+//        return reinterpret_cast<const _T&>(*buff_.data());
+//    }
+
+//    template <typename _T>
+//    typename std::enable_if<std::is_pointer<_T>::value, _T>::type
+//    get()
+//    {
+//        is_stored_type<_T>();
+//        return reinterpret_cast<_T>(buff_.data());
+//    }
+
+//    template <typename _T>
+//    typename std::enable_if<std::is_pointer<_T>::value, const _T>::type
+//    get() const
+//    {
+//        is_stored_type<_T>();
+//        return reinterpret_cast<const _T>(buff_.data());
+//    }
 
     template <typename _T>
-    typename std::enable_if<!std::is_pointer<_T>::value, const _T&>::type
-    get() const
+    bool is_stored_type() const
     {
-        is_stored_type<_T>();
-        return reinterpret_cast<const _T&>(*buff_.data());
-    }
-
-    template <typename _T>
-    typename std::enable_if<std::is_pointer<_T>::value, _T>::type
-    get()
-    {
-        is_stored_type<_T>();
-        return reinterpret_cast<_T>(buff_.data());
-    }
-
-    template <typename _T>
-    typename std::enable_if<std::is_pointer<_T>::value, const _T>::type
-    get() const
-    {
-        is_stored_type<_T>();
-        return reinterpret_cast<const _T>(buff_.data());
+        using NonConstT = std::remove_cv_t<_T>;
+        return function_ == get_function_for_type<NonConstT>();
     }
 
 private:
-    template <typename _T>
-    void copy_object(_T&& t)
-    {
-        static_assert(std::is_trivially_copyable<_T>::value, "_T is not trivially copyable");
-        static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
 
-        std::memcpy(buff_.data(), (char*)&t, sizeof(_T));
-        type_ = typeid(_T).hash_code();
+    // Pointer to administrative function, function that will by type-specific, and will be able to perform all the required operations
+    enum class operation_t { copy, move, destroy };
+    using function_ptr_t = void(*)(operation_t operation, void* this_ptr, void* other_ptr);
+
+    template<typename _T>
+    static function_ptr_t get_function_for_type()
+    {
+        return [](operation_t operation, void* this_void_ptr, void* other_void_ptr)
+        {
+            _T* this_ptr = reinterpret_cast<_T*>(this_void_ptr);
+            _T* other_ptr = reinterpret_cast<_T*>(other_void_ptr);
+
+            switch(operation)
+            {
+                case operation_t::copy:
+                    assert(this_ptr);
+                    assert(other_ptr);
+                    new(this_ptr)_T(*other_ptr);
+                    break;
+                case operation_t::move:
+                    assert(this_ptr);
+                    assert(other_ptr);
+                    new(this_ptr)_T(std::move(*other_ptr));
+                    break;
+                case operation_t::destroy:
+                    assert(this_ptr);
+                    this_ptr->~_T();
+                    break;
+            }
+        };
     }
 
     template <typename _T>
-    void is_stored_type()
+    void copy_object(const _T& t)
     {
-        if (type_ != typeid(_T).hash_code())
-            throw std::bad_cast();
+        static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
+        assert(!function_);
+        using NonConstT = std::remove_cv_t<_T>;
+        function_ = get_function_for_type<NonConstT>();
+        _T* non_const_t = const_cast<_T*>(&t);
+        function_(operation_t::copy, buff_.data(), non_const_t);
+    }
+
+    template <typename _T>
+    void move_object(_T& t)
+    {
+        static_assert(size() >= sizeof(_T), "_T is too big to be copied to any_p");
+        assert(!function_);
+        using NonConstT = std::remove_cv_t<_T>;
+        function_ = get_function_for_type<NonConstT>();
+        //TP<_T> x;
+        NonConstT* non_const_t = const_cast<NonConstT*>(&t);
+        function_(operation_t::move, buff_.data(), &non_const_t);
+    }
+
+
+    void destroy()
+    {
+        if (function_)
+        {
+            function_(operation_t::destroy, buff_.data(), nullptr);
+            function_ = nullptr;
+        }
     }
 
     std::array<char, _N> buff_;
-    std::size_t          type_;
+    function_ptr_t function_ = nullptr;
 };

--- a/any.hpp
+++ b/any.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 #include <typeinfo>
 #include <cassert>
-#include <iostream>
 
 namespace detail
 {
@@ -77,8 +76,6 @@ private:
 
     std::array<char, _N> buff_;
 };
-
-template<typename T> class TP;
 
 template <std::size_t _N>
 struct any_p

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -325,3 +325,34 @@ TEST(any_p, mutable_get)
     auto i = const_ref.get<int>();
     ASSERT_EQ(6, i);
 }
+
+TEST(any_p, any_to_any_copy_uninitialized)
+{
+    any_p<16> a;
+    any_p<16> b(a);
+
+    ASSERT_TRUE(a.empty());
+    ASSERT_TRUE(b.empty());
+}
+
+TEST(any_p, any_to_any_copy_construction)
+{
+    any_p<16> a(7);
+    any_p<16> b(a);
+
+    ASSERT_EQ(7, a.get<int>());
+    ASSERT_EQ(7, b.get<int>());
+}
+
+TEST(any_p, any_to_any_assignment)
+{
+    any_p<32> a(std::string("Hello"));
+    any_p<32> b;
+
+    ASSERT_TRUE(b.empty());
+    b = a;
+    ASSERT_FALSE(b.empty());
+
+    ASSERT_EQ("Hello", b.get<std::string>());
+    ASSERT_EQ("Hello", a.get<std::string>());
+}

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -246,6 +246,19 @@ TEST(any_p, destruction)
     ASSERT_EQ(1, CallCounter::destructions);
 }
 
+TEST(any_p, copy_assignment)
+{
+    CallCounter::reset_counters();
+    CallCounter counter;
+
+    any_p<16> a;
+    a = counter;
+
+    ASSERT_EQ(1, CallCounter::default_constructions);
+    ASSERT_EQ(1, CallCounter::copy_constructions);
+    ASSERT_EQ(0, CallCounter::move_constructions);
+}
+
 TEST(any_p, move_assignment)
 {
     CallCounter::reset_counters();
@@ -268,8 +281,47 @@ TEST(any_p, reassignment)
     a = counter;
 
     ASSERT_EQ(1, CallCounter::default_constructions);
-    ASSERT_EQ(1, CallCounter::copy_constructions);
-    ASSERT_EQ(1, CallCounter::move_constructions);
+    ASSERT_EQ(2, CallCounter::copy_constructions);
+    ASSERT_EQ(0, CallCounter::move_constructions);
     ASSERT_EQ(1, CallCounter::destructions);
 }
 
+TEST(any_p, not_empty_after_assignment)
+{
+    any_p<16> a;
+    ASSERT_TRUE(a.empty());
+    a = 7;
+    ASSERT_FALSE(a.empty());
+}
+
+TEST(any_p, different_type_after_assignment)
+{
+    any_p<16> a(7);
+    ASSERT_TRUE(a.is_stored_type<int>());
+    ASSERT_FALSE(a.is_stored_type<double>());
+    a = 3.14;
+    ASSERT_FALSE(a.is_stored_type<int>());
+    ASSERT_TRUE(a.is_stored_type<double>());
+}
+
+TEST(any_p, get_good_type)
+{
+    any_p<16> a(7);
+    auto i = a.get<int>();
+    ASSERT_EQ(7, i);
+}
+
+TEST(any_p, get_bad_type)
+{
+    any_p<16> a(7);
+    EXPECT_THROW(a.get<double>(), std::bad_cast);
+}
+
+TEST(any_p, mutable_get)
+{
+    any_p<16> a(7);
+    a.get<int>() = 6;
+    const any_p<16>& const_ref = a;
+    auto i = const_ref.get<int>();
+    ASSERT_EQ(6, i);
+}


### PR DESCRIPTION
New implementation of any_p, using function pointer as a gateway to the typed code.
Some more features can be added, for instance:
* assignment form any of another, smaller size
* assignment form any of bigger size, with runtime check of the object size
* support for move-only objects, with runtime error when copying any_p containing move-only type.

All above doable, but I'm not sure if needed.

And I fixed some mess in the CMakeLists.txt. This hardcoded -O3 costed me some blood...